### PR TITLE
Implement a rule command.

### DIFF
--- a/config.c
+++ b/config.c
@@ -40,6 +40,15 @@ struct wl_list *config_root = &root_group.group;
 static uint32_t mod = SWC_MOD_LOGO;
 static const char whitespace[] = " \t\n";
 
+static void
+strip_newline(char *s)
+{
+	char *newline;
+
+	if ((newline = strchr(s, '\n')))
+		*newline = '\0';
+}
+
 static bool
 parse_modifier(const char *string, uint32_t *modifier)
 {
@@ -137,7 +146,7 @@ handle_set(char *s)
 
 struct spawn_action {
 	struct config_node node;
-	const char *command;
+	char *command;
 };
 
 static void
@@ -158,10 +167,8 @@ static struct config_node *
 spawn_action(char *command)
 {
 	struct spawn_action *action;
-	char *newline;
 
-	if ((newline = strchr(command, '\n')))
-		*newline = '\0';
+	strip_newline(command);
 
 	if (!(action = malloc(sizeof *action)))
 		return NULL;
@@ -389,7 +396,7 @@ handle_button(char *s)
 static bool
 handle_rule(char *s)
 {
-	char *identifier, *type, *newline;
+	char *identifier, *type;
 	struct rule *rule;
 	struct config_node *action;
 
@@ -404,8 +411,7 @@ handle_rule(char *s)
 	}
 
 	s += strspn(s, whitespace);
-	if ((newline = strchr(s, '\n')))
-		*newline = '\0';
+	strip_newline(s);
 
 	if (!(action = lookup(s)) || action->type != CONFIG_NODE_TYPE_ACTION) {
 		fprintf(stderr, "Could not find action '%s'\n", s);

--- a/config.c
+++ b/config.c
@@ -140,7 +140,7 @@ struct spawn_action {
 };
 
 static void
-spawn(struct config_node *node)
+spawn(struct config_node *node, const struct variant *v)
 {
 	struct spawn_action *action = wl_container_of(node, action, node);
 
@@ -237,9 +237,9 @@ key_binding(void *data, uint32_t time, uint32_t value, uint32_t state)
 	struct binding *binding = data;
 
 	if (state == WL_KEYBOARD_KEY_STATE_PRESSED && binding->press)
-		binding->press->action.run(binding->press);
+		binding->press->action.run(binding->press, NULL);
 	else if (binding->release)
-		binding->release->action.run(binding->release);
+		binding->release->action.run(binding->release, NULL);
 }
 
 static void
@@ -248,9 +248,9 @@ button_binding(void *data, uint32_t time, uint32_t value, uint32_t state)
 	struct binding *binding = data;
 
 	if (state == WL_POINTER_BUTTON_STATE_PRESSED && binding->press)
-		binding->press->action.run(binding->press);
+		binding->press->action.run(binding->press, NULL);
 	else if (binding->release)
-		binding->release->action.run(binding->release);
+		binding->release->action.run(binding->release, NULL);
 }
 
 static void (*binding_handler[])(void *, uint32_t, uint32_t, uint32_t) = {

--- a/config.h
+++ b/config.h
@@ -33,6 +33,15 @@ enum config_node_type {
 	CONFIG_NODE_TYPE_ACTION
 };
 
+struct variant {
+	enum {
+		VARIANT_WINDOW,
+	} type;
+	union {
+		struct window *window;
+	};
+};
+
 struct config_node {
 	const char *name;
 	enum config_node_type type;
@@ -42,9 +51,8 @@ struct config_node {
 		struct {
 			bool (*set)(struct config_node *node, const char *value);
 		} property;
-		struct
-		    {
-			void (*run)(struct config_node *node);
+		struct {
+			void (*run)(struct config_node *node, const struct variant *v);
 		} action;
 	};
 

--- a/layout.c
+++ b/layout.c
@@ -229,7 +229,7 @@ error0:
 }
 
 static void
-increase_master_size(struct config_node *node)
+increase_master_size(struct config_node *node, const struct variant *v)
 {
 	struct tall_layout *layout;
 
@@ -241,7 +241,7 @@ increase_master_size(struct config_node *node)
 }
 
 static void
-decrease_master_size(struct config_node *node)
+decrease_master_size(struct config_node *node, const struct variant *v)
 {
 	struct tall_layout *layout;
 
@@ -253,7 +253,7 @@ decrease_master_size(struct config_node *node)
 }
 
 static void
-increase_num_masters(struct config_node *node)
+increase_num_masters(struct config_node *node, const struct variant *v)
 {
 	struct tall_layout *layout;
 
@@ -265,7 +265,7 @@ increase_num_masters(struct config_node *node)
 }
 
 static void
-decrease_num_masters(struct config_node *node)
+decrease_num_masters(struct config_node *node, const struct variant *v)
 {
 	struct tall_layout *layout;
 
@@ -277,7 +277,7 @@ decrease_num_masters(struct config_node *node)
 }
 
 static void
-increase_num_columns(struct config_node *node)
+increase_num_columns(struct config_node *node, const struct variant *v)
 {
 	struct tall_layout *layout;
 
@@ -289,7 +289,7 @@ increase_num_columns(struct config_node *node)
 }
 
 static void
-decrease_num_columns(struct config_node *node)
+decrease_num_columns(struct config_node *node, const struct variant *v)
 {
 	struct tall_layout *layout;
 

--- a/tag.c
+++ b/tag.c
@@ -63,7 +63,7 @@ set_name(struct config_node *node, const char *value)
 }
 
 static void
-activate(struct config_node *node)
+activate(struct config_node *node, const struct variant *v)
 {
 	struct tag *tag = wl_container_of(node, tag, config.activate);
 	struct screen *screen = velox.active_screen;
@@ -74,7 +74,7 @@ activate(struct config_node *node)
 }
 
 static void
-toggle(struct config_node *node)
+toggle(struct config_node *node, const struct variant *v)
 {
 	struct tag *tag = wl_container_of(node, tag, config.toggle);
 	struct screen *screen = velox.active_screen;
@@ -84,15 +84,15 @@ toggle(struct config_node *node)
 }
 
 static void
-apply(struct config_node *node)
+apply(struct config_node *node, const struct variant *v)
 {
 	struct tag *tag = wl_container_of(node, tag, config.apply);
-	struct window *window = velox.active_screen->focus;
+	struct window *w = window_or_focus(v);
 
-	if (!window)
+	if (!w)
 		return;
 
-	window_set_tag(window, tag);
+	window_set_tag(w, tag);
 	update();
 }
 

--- a/velox.c
+++ b/velox.c
@@ -1,6 +1,7 @@
 /* velox: velox.c
  *
  * Copyright (c) 2014 Michael Forney
+ * Copyright (c) 2015 Jente Hidskes
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -93,17 +94,53 @@ static const struct velox_interface velox_implementation = {
 	.get_screen = &get_screen,
 };
 
+static void
+apply_rules(struct window *window)
+{
+	struct rule *rule;
+	const char *identifier;
+
+	wl_list_for_each (rule, &velox.rules, link) {
+		switch (rule->type) {
+		case RULE_TYPE_WINDOW_TITLE:
+			identifier = window->swc->title;
+			break;
+		case RULE_TYPE_APP_ID:
+			identifier = window->swc->app_id;
+			break;
+		default:
+			identifier = NULL;
+			break;
+		}
+
+		if (!identifier)
+			continue;
+
+		// TODO: support quoted window titles.
+		if (strcmp(identifier, rule->identifier) == 0) {
+			struct config_node *node = rule->action;
+			const struct variant v = {
+				.type = VARIANT_WINDOW,
+				.window = window
+			};
+
+			node->action.run(node, &v);
+		}
+	}
+}
+
 void
 manage(struct window *window)
 {
 	struct tag *tag;
 
-	/* TODO: Add support for rules to automatically assign a tag to certain
-	 * windows. */
-
 	wl_list_insert(&velox.hidden_windows, &window->link);
-	tag = wl_container_of(velox.active_screen->tags.next, tag, link);
-	window_set_tag(window, tag);
+
+	apply_rules(window);
+	if (!window->tag) {
+		tag = wl_container_of(velox.active_screen->tags.next, tag, link);
+		window_set_tag(window, tag);
+	}
 	if (window->tag->screen)
 		screen_set_focus(window->tag->screen, window);
 	update();
@@ -331,6 +368,7 @@ main(int argc, char *argv[])
 	wl_list_init(&velox.screens);
 	wl_list_init(&velox.hidden_windows);
 	wl_list_init(&velox.unused_tags);
+	wl_list_init(&velox.rules);
 	add_config_nodes();
 
 	for (index = 0; index < NUM_TAGS; ++index, ++tag_name[0]) {

--- a/velox.c
+++ b/velox.c
@@ -177,19 +177,19 @@ find_unused_tag()
 
 /**** Actions ****/
 static void
-focus_next(struct config_node *node)
+focus_next(struct config_node *node, const struct variant *v)
 {
 	screen_focus_next(velox.active_screen);
 }
 
 static void
-focus_prev(struct config_node *node)
+focus_prev(struct config_node *node, const struct variant *v)
 {
 	screen_focus_prev(velox.active_screen);
 }
 
 static void
-zoom(struct config_node *node)
+zoom(struct config_node *node, const struct variant *v)
 {
 	struct screen *screen = velox.active_screen;
 	struct wl_list *link;
@@ -214,7 +214,7 @@ zoom(struct config_node *node)
 }
 
 static void
-layout_next(struct config_node *node)
+layout_next(struct config_node *node, const struct variant *v)
 {
 	struct screen *screen = velox.active_screen;
 	struct layout **layout = &screen->layout[TILE];
@@ -227,7 +227,7 @@ layout_next(struct config_node *node)
 }
 
 static void
-previous_tags(struct config_node *node)
+previous_tags(struct config_node *node, const struct variant *v)
 {
 	uint32_t mask = velox.active_screen->last_mask;
 
@@ -237,7 +237,7 @@ previous_tags(struct config_node *node)
 }
 
 static void
-quit(struct config_node *node)
+quit(struct config_node *node, const struct variant *v)
 {
 	wl_display_terminate(velox.display);
 }

--- a/velox.conf.sample
+++ b/velox.conf.sample
@@ -20,6 +20,9 @@ set tag.9.name                      9
 action spawn_terminal   spawn   st-wl
 action spawn_run        spawn   dmenu_run-wl -b -fn Terminus:pixelsize=14 -nb "#1a1a1a" -nf "#999999" -sb "#338833" -sf "#ffffff"
 
+#      type    identifier   action
+rule   title   st           tag.2.apply
+
 #   key         modifiers           action
 key j           mod                 focus_next
 key k           mod                 focus_prev

--- a/velox.h
+++ b/velox.h
@@ -1,6 +1,7 @@
 /* velox: velox.h
  *
  * Copyright (c) 2014 Michael Forney
+ * Copyright (c) 2015 Jente Hidskes
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +31,17 @@
 
 struct window;
 
+struct rule {
+	enum rule_type {
+		RULE_TYPE_WINDOW_TITLE,
+		RULE_TYPE_APP_ID,
+	} type;
+	char *identifier;
+	struct config_node *action;
+
+	struct wl_list link;
+};
+
 struct velox {
 	struct wl_display *display;
 	struct wl_event_loop *event_loop;
@@ -37,6 +49,7 @@ struct velox {
 	struct wl_list screens;
 	struct wl_list hidden_windows;
 	struct wl_list unused_tags;
+	struct wl_list rules;
 	struct tag *tags[NUM_TAGS];
 
 	struct wl_global *global;

--- a/window.h
+++ b/window.h
@@ -27,6 +27,7 @@
 #include <wayland-server.h>
 
 struct swc_window;
+struct variant;
 
 struct window {
 	struct swc_window *swc;
@@ -46,5 +47,7 @@ void window_hide(struct window *window);
 
 void window_set_tag(struct window *window, struct tag *tag);
 void window_set_layer(struct window *window, int layer);
+
+struct window *window_or_focus(const struct variant *v);
 
 #endif


### PR DESCRIPTION
I saw the TODO in `velox.c` and thought I'd have a go.

As you can see, I implemented a new `rule` command that can receive several types just like the `action` command. For now, I implemented only a `tag` type, which will move a window to a certain tag. Other types could for example be to automatically make windows float.

Two things have not been worked out yet. I wanted your feedback on this before making a decision myself:
* The current implementation does not support window titles spanning several words, e.g. "Mozilla Firefox". This is due to the matching being done with `strtok_r` separating on whitespaces. A solution would be to add support for quoted strings, or to change the order of the `rule` command to `rule <type> <argument> <window title>` (so for the `tag` type, it will be `rule tag 1 Mozilla Firefox`);
* Rules are added directly to `config_root`. Maybe you would like to have a separate group for all the rules?

Looking forward to your feedback!