### PR TITLE
config: add support for quoted window titles

### DIFF
--- a/config.c
+++ b/config.c
@@ -417,7 +417,14 @@ handle_rule(char *s)
 		goto error0;
 	}
 
-	if (!(identifier = strtok_r(NULL, whitespace, &s))) {
+	if (strchr(s, '"')) {
+		strtok_r(NULL, "\"", &s);
+		identifier = strtok_r(NULL, "\"", &s);
+	} else {
+		identifier = strtok_r(NULL, whitespace, &s);
+	}
+
+	if (!identifier) {
 		fprintf(stderr, "No window identifier specified\n");
 		goto error0;
 	}

--- a/velox.c
+++ b/velox.c
@@ -116,7 +116,6 @@ apply_rules(struct window *window)
 		if (!identifier)
 			continue;
 
-		// TODO: support quoted window titles.
 		if (strcmp(identifier, rule->identifier) == 0) {
 			struct config_node *node = rule->action;
 			const struct variant v = {


### PR DESCRIPTION
As mentioned in #13. I wasn't sure what the best way was to go about it, so besides this version there is also another one without a double `strtok` in the [quoted-variables2](https://github.com/Unia/velox/commit/46b58a4fbbced69498ede7f4cd013398d31cc936) branch. That version might be slightly faster/have slightly less overhead, but it's less readable.

I can imagine there are countless other ways to go about this, so feel free to reject this for another solution.